### PR TITLE
Add short delay to avoid blocking

### DIFF
--- a/frida-ios-hook/frida-scripts/find-all-classes.js
+++ b/frida-ios-hook/frida-scripts/find-all-classes.js
@@ -13,4 +13,5 @@ function show_classes_of_app()
     console.log("\n[*] Classes found: " + count);
     console.log("[*] Completed: Find Classes")
 }
-show_classes_of_app()
+
+setTimeout(show_classes_of_app, 1000);


### PR DESCRIPTION
Usually, the script works very well for me. However, it blocks the main thread for me, and delays the start of the app. It also crashes for some apps.

The proposed change does two things:

1. It does the class dumping asynchronously, so app loading isn't delayed anymore (I think).
2. For a small number of very large apps (size more than 1GB, less than 1% of all apps), it prevents crashes, and failure of class dumping by delaying the class dumping operation.