### PR TITLE
use global value for frida-scripts

### DIFF
--- a/frida-ios-hook/core/hook.py
+++ b/frida-ios-hook/core/hook.py
@@ -178,6 +178,8 @@ def main():
 
         #Spawning application and load script
         elif options.package and options.script:
+            if not os.path.isfile(options.script):
+                options.script =  APP_FRIDA_SCRIPTS +'/'+options.script            
             if os.path.isfile(options.script):
                 logger.info('[*] Spawning: ' + options.package)
                 logger.info('[*] Script: ' + options.script)
@@ -196,6 +198,8 @@ def main():
         
         #Attaching script to application
         elif options.name and options.script:
+            if not os.path.isfile(options.script):
+                options.script =  APP_FRIDA_SCRIPTS + '/'+options.script
             if os.path.isfile(options.script):
                 logger.info('[*] Attaching: ' + options.name)
                 logger.info('[*] Script: ' + options.script)


### PR DESCRIPTION
when i use ioshook -n "xxx" -s backtrace.js
show [ERROR] - [?] Script not found!
i don't want to wirte so long dir